### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@
 - [Agenta](https://github.com/agenta-ai/agenta) -  Easily build, version, evaluate and deploy your LLM-powered apps.
 - [Embedchain](https://github.com/embedchain/embedchain) - Framework to create ChatGPT like bots over your dataset.
 
+
 ## Courses about LLM
 
 - [DeepLearning.AI] ChatGPT Prompt Engineering for Developers [Homepage](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/)
@@ -526,6 +527,7 @@
 - [ModelFusion](https://github.com/lgrammel/modelfusion) - A TypeScript library for building apps with LLMs and other ML models (speech-to-text, text-to-speech, image generation).
 - [Flappy](https://github.com/pleisto/flappy) — Production-Ready LLM Agent SDK for Every Developer.
 - [GPTRouter](https://gpt-router.writesonic.com/) - GPTRouter is an open source LLM API Gateway that offers a universal API for 30+ LLMs, vision, and image models, with smart fallbacks based on uptime and latency, automatic retries, and streaming. Stay operational even when OpenAI is down
+- [Future AGI](https://github.com/future-agi/future-agi) — Open-source, self-hostable platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop.
 
 ## Datasets of In-Context Learning
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the Prompting libraries & tools section.

Future AGI is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.