### PR TITLE
Add MMESGBench (multimodal ESG benchmark) to Benchmarks for Knowledge and Reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,10 @@ We build a decision flow for choosing LLMs or fine-tuned models~\protect\footnot
 
     *Hui Zeng* *et al.* arXiv 2023. [[Paper](https://arxiv.org/ftp/arxiv/papers/2308/2308.04823.pdf)] [[Source](http://cgeval.besteasy.com/)] [[GitHub](https://github.com/Felixgithub2017/CG-Eval)] 
 
+9. MMESGBench: **"MMESGBench: Pioneering Multimodal Understanding and Complex Reasoning Benchmark for ESG Tasks"**. ![](https://img.shields.io/badge/Dataset-blue)
+
+    *Lei Zhang et al.* ACM MM 2025. [[Paper](https://arxiv.org/abs/2507.18932)] [[GitHub](https://github.com/Zhanglei1103/MMESGBench)] 
+
 #### Benchmark for Holistic Evaluation
 
 1. Big-bench: **"Beyond the Imitation Game: Quantifying and extrapolating the capabilities of language models"**. ![](https://img.shields.io/badge/Dataset-blue)


### PR DESCRIPTION
Adds **MMESGBench** (ACM Multimedia 2025) to **Benchmarks for Knowledge and Reasoning**.

First multimodal benchmark for understanding and complex reasoning over real-world **ESG documents**: 933 validated QA pairs from 45 documents (7 document types, 3 ESG source categories), with single-page / cross-page / unanswerable questions and fine-grained multimodal evidence (text, tables, charts/layout).

- Paper: https://arxiv.org/abs/2507.18932 (ACM MM 2025)
- Code/Dataset: https://github.com/Zhanglei1103/MMESGBench

Follows the numbered entry format with the Dataset badge.